### PR TITLE
Using Browser Node for nodeType values

### DIFF
--- a/content.js
+++ b/content.js
@@ -7,9 +7,9 @@ function walk(node)
 
 	switch ( node.nodeType )
 	{
-		case 1:  // Element
-		case 9:  // Document
-		case 11: // Document fragment
+		case Node.ELEMENT_NODE:
+		case Node.DOCUMENT_NODE:
+		case Node.DOCUMENT_FRAGMENT_NODE:
 			child = node.firstChild;
 			while ( child )
 			{
@@ -19,7 +19,7 @@ function walk(node)
 			}
 			break;
 
-		case 3: // Text node
+		case Node.TEXT_NODE:
 			handleText(node);
 			break;
 	}


### PR DESCRIPTION
Updated to use more readable in-browser `Node` `nodeType` values.

Feedback for Issue https://github.com/jordan-miguel/Crazy-Hate-Group/issues/1
